### PR TITLE
feat: sarif-validator action

### DIFF
--- a/actions/sarif-validator/README.md
+++ b/actions/sarif-validator/README.md
@@ -1,0 +1,79 @@
+# sarif-validator
+
+Validate a SARIF file before uploading to GitHub code scanning. Catches schema errors, missing required fields, malformed rules, and common gotchas that cause silent upload failures or misleading results in the GitHub UI.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `sarif_file` | Yes | — | Path to the SARIF file to validate |
+| `strict` | No | `false` | Fail on warnings as well as errors |
+| `max_results` | No | — | Warn if result count exceeds this threshold |
+
+## Checks
+
+| Check | Failure Mode |
+|---|---|
+| Valid JSON | error |
+| SARIF version present and = `2.1.0` | error |
+| Required top-level fields (`version`, `runs`) | error |
+| `tool.driver.name` present in each run | error |
+| No duplicate `ruleId`s in rules array | error |
+| All result `ruleId`s reference a known rule | error |
+| All results have a location with URI and `startLine` | warning |
+| No absolute URI paths (won't resolve in GitHub UI) | warning |
+| All `level` values are valid (`error`, `warning`, `note`, `none`) | error |
+| Result count ≤ `max_results` (if set) | warning |
+
+## Usage
+
+### Validate before upload
+
+```yaml
+- name: Validate SARIF
+  uses: cschooley/ghas-actions/actions/sarif-validator@main
+  with:
+    sarif_file: results.sarif
+
+- name: Upload to GitHub code scanning
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: results.sarif
+```
+
+### Strict mode with result cap
+
+```yaml
+- uses: cschooley/ghas-actions/actions/sarif-validator@main
+  with:
+    sarif_file: results.sarif
+    strict: true
+    max_results: 500
+```
+
+See [examples/validate-before-upload.yml](examples/validate-before-upload.yml) for a full workflow.
+
+## Output
+
+```
+SARIF Validation: results.sarif
+------------------------------------------------------------
+[PASS] Valid JSON
+[PASS] Schema version: 2.1.0
+[PASS] 'runs' present (1 run(s))
+[PASS] Run 1: tool.driver.name = 'CodeQL'
+[PASS] Run 1: no duplicate ruleIds (42 rule(s))
+[PASS] Run 1: all result ruleIds reference known rules
+[PASS] Run 1: all results have valid locations
+[PASS] Run 1: URI patterns look sane
+[PASS] Run 1: all level values are valid
+------------------------------------------------------------
+Summary: 156 result(s), 42 unique rule(s)
+
+Result: PASS
+```
+
+## Known Limitations
+
+- Does not validate against the full JSON Schema for SARIF 2.1.0 — checks are targeted at the fields GitHub code scanning actually uses
+- `level` at the `rule.defaultConfiguration` level is not checked, only result-level `level`

--- a/actions/sarif-validator/action.yml
+++ b/actions/sarif-validator/action.yml
@@ -1,0 +1,27 @@
+name: 'SARIF Validator'
+description: 'Validate a SARIF file before uploading to GitHub code scanning'
+author: 'cschooley'
+
+inputs:
+  sarif_file:
+    description: 'Path to the SARIF file to validate'
+    required: true
+  strict:
+    description: 'Fail on warnings as well as errors'
+    required: false
+    default: 'false'
+  max_results:
+    description: 'Warn if result count exceeds this threshold'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Validate SARIF file
+      run: python ${{ github.action_path }}/src/validate.py
+      shell: bash
+      env:
+        INPUT_SARIF_FILE: ${{ inputs.sarif_file }}
+        INPUT_STRICT: ${{ inputs.strict }}
+        INPUT_MAX_RESULTS: ${{ inputs.max_results }}

--- a/actions/sarif-validator/examples/validate-before-upload.yml
+++ b/actions/sarif-validator/examples/validate-before-upload.yml
@@ -1,0 +1,31 @@
+name: Validate and Upload SARIF
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  scan-and-validate:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Run your scanner here — this example uses a hypothetical tool
+      - name: Run scanner
+        run: my-scanner --output results.sarif
+
+      - name: Validate SARIF
+        uses: cschooley/ghas-actions/actions/sarif-validator@main
+        with:
+          sarif_file: results.sarif
+          strict: false
+          max_results: 1000
+
+      - name: Upload to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/actions/sarif-validator/src/validate.py
+++ b/actions/sarif-validator/src/validate.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+SUPPORTED_VERSIONS = {"2.1.0"}
+VALID_LEVELS = {"error", "warning", "note", "none"}
+ABSOLUTE_PATH_RE = re.compile(r'^(/|[A-Za-z]:[/\\])')
+
+
+def check(status: str, message: str) -> dict:
+    return {"status": status, "message": message}
+
+
+def validate_json(content: str) -> tuple[dict | None, dict]:
+    try:
+        return json.loads(content), check("pass", "Valid JSON")
+    except json.JSONDecodeError as e:
+        return None, check("fail", f"Invalid JSON: {e}")
+
+
+def validate_top_level(sarif: dict) -> list[dict]:
+    results = []
+    version = sarif.get("version")
+    if not version:
+        results.append(check("fail", "Missing required field: 'version'"))
+    elif version not in SUPPORTED_VERSIONS:
+        results.append(check("fail", f"Unsupported SARIF version '{version}'. Supported: {', '.join(SUPPORTED_VERSIONS)}"))
+    else:
+        results.append(check("pass", f"Schema version: {version}"))
+
+    if "runs" not in sarif:
+        results.append(check("fail", "Missing required field: 'runs'"))
+    elif not isinstance(sarif["runs"], list) or len(sarif["runs"]) == 0:
+        results.append(check("fail", "'runs' must be a non-empty array"))
+    else:
+        results.append(check("pass", f"'runs' present ({len(sarif['runs'])} run(s))"))
+
+    return results
+
+
+def validate_run(run: dict, run_index: int) -> list[dict]:
+    prefix = f"Run {run_index + 1}"
+    results = []
+
+    # tool.driver.name
+    driver_name = run.get("tool", {}).get("driver", {}).get("name")
+    if not driver_name:
+        results.append(check("fail", f"{prefix}: missing tool.driver.name"))
+    else:
+        results.append(check("pass", f"{prefix}: tool.driver.name = '{driver_name}'"))
+
+    # rules
+    rules = run.get("tool", {}).get("driver", {}).get("rules") or []
+    rule_ids = [r.get("id") for r in rules if r.get("id")]
+
+    dupes = {rid for rid in rule_ids if rule_ids.count(rid) > 1}
+    if dupes:
+        results.append(check("fail", f"{prefix}: duplicate ruleIds: {', '.join(sorted(dupes))}"))
+    else:
+        results.append(check("pass", f"{prefix}: no duplicate ruleIds ({len(rule_ids)} rule(s))"))
+
+    rule_id_set = set(rule_ids)
+    sarif_results = run.get("results") or []
+
+    # results ruleId references
+    unknown_rule_ids = set()
+    for r in sarif_results:
+        rid = r.get("ruleId")
+        if rid and rule_id_set and rid not in rule_id_set:
+            unknown_rule_ids.add(rid)
+    if unknown_rule_ids:
+        results.append(check("fail", f"{prefix}: results reference unknown ruleIds: {', '.join(sorted(unknown_rule_ids))}"))
+    else:
+        results.append(check("pass", f"{prefix}: all result ruleIds reference known rules"))
+
+    # locations
+    missing_location = 0
+    bad_uri = []
+    for i, r in enumerate(sarif_results):
+        locations = r.get("locations") or []
+        if not locations:
+            missing_location += 1
+            continue
+        for loc in locations:
+            phys = loc.get("physicalLocation") or {}
+            artifact = phys.get("artifactLocation") or {}
+            uri = artifact.get("uri", "")
+            if uri and ABSOLUTE_PATH_RE.match(uri):
+                bad_uri.append(uri)
+            region = phys.get("region") or {}
+            if not region.get("startLine"):
+                missing_location += 1
+
+    if missing_location:
+        results.append(check("warn", f"{prefix}: {missing_location} result(s) missing a valid location (URI + startLine)"))
+    else:
+        results.append(check("pass", f"{prefix}: all results have valid locations"))
+
+    if bad_uri:
+        sample = bad_uri[:3]
+        results.append(check("warn", f"{prefix}: {len(bad_uri)} result(s) use absolute URIs that won't resolve in GitHub UI (e.g. {sample[0]})"))
+    else:
+        results.append(check("pass", f"{prefix}: URI patterns look sane"))
+
+    # level values
+    invalid_levels = set()
+    for r in sarif_results:
+        level = r.get("level")
+        if level and level not in VALID_LEVELS:
+            invalid_levels.add(level)
+    if invalid_levels:
+        results.append(check("fail", f"{prefix}: invalid level values: {', '.join(sorted(invalid_levels))}. Valid: {', '.join(sorted(VALID_LEVELS))}"))
+    else:
+        results.append(check("pass", f"{prefix}: all level values are valid"))
+
+    return results, len(sarif_results), len(rule_id_set)
+
+
+def format_status(status: str) -> str:
+    return {"pass": "[PASS]", "fail": "[FAIL]", "warn": "[WARN]"}[status]
+
+
+def main() -> None:
+    sarif_file = os.environ.get("INPUT_SARIF_FILE", "").strip()
+    strict = os.environ.get("INPUT_STRICT", "false").strip().lower() in ("true", "1", "yes")
+    max_results_raw = os.environ.get("INPUT_MAX_RESULTS", "").strip()
+    max_results = int(max_results_raw) if max_results_raw.isdigit() else None
+
+    if not sarif_file:
+        print("ERROR: 'sarif_file' input is required.", file=sys.stderr)
+        sys.exit(2)
+    if not os.path.exists(sarif_file):
+        print(f"ERROR: File not found: {sarif_file}", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"SARIF Validation: {sarif_file}")
+    print("-" * 60)
+
+    with open(sarif_file) as f:
+        content = f.read()
+
+    all_checks = []
+
+    sarif, json_check = validate_json(content)
+    all_checks.append(json_check)
+    print(f"{format_status(json_check['status'])} {json_check['message']}")
+
+    if sarif is None:
+        sys.exit(1)
+
+    for c in validate_top_level(sarif):
+        all_checks.append(c)
+        print(f"{format_status(c['status'])} {c['message']}")
+
+    has_runs = isinstance(sarif.get("runs"), list) and len(sarif["runs"]) > 0
+    total_results = 0
+    total_rules = 0
+
+    if has_runs:
+        for i, run in enumerate(sarif["runs"]):
+            run_checks, result_count, rule_count = validate_run(run, i)
+            total_results += result_count
+            total_rules += rule_count
+            for c in run_checks:
+                all_checks.append(c)
+                print(f"{format_status(c['status'])} {c['message']}")
+
+    if max_results is not None and total_results > max_results:
+        c = check("warn", f"Result count {total_results} exceeds max_results threshold of {max_results}")
+        all_checks.append(c)
+        print(f"{format_status(c['status'])} {c['message']}")
+
+    print("-" * 60)
+    print(f"Summary: {total_results} result(s), {total_rules} unique rule(s)")
+
+    has_failures = any(c["status"] == "fail" for c in all_checks)
+    has_warnings = any(c["status"] == "warn" for c in all_checks)
+
+    if has_failures:
+        print(f"\nResult: FAIL ({sum(1 for c in all_checks if c['status'] == 'fail')} error(s))")
+        sys.exit(1)
+    if strict and has_warnings:
+        print(f"\nResult: FAIL — strict mode ({sum(1 for c in all_checks if c['status'] == 'warn')} warning(s))")
+        sys.exit(1)
+    print("\nResult: PASS")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sarif-validator/test_validate.py
+++ b/tests/sarif-validator/test_validate.py
@@ -1,0 +1,260 @@
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../actions/sarif-validator/src"))
+import validate
+
+
+def make_sarif(
+    version="2.1.0",
+    runs=None,
+    include_version=True,
+    include_runs=True,
+) -> dict:
+    sarif = {}
+    if include_version:
+        sarif["version"] = version
+    if include_runs:
+        sarif["runs"] = runs if runs is not None else [make_run()]
+    return sarif
+
+
+def make_run(
+    driver_name="TestTool",
+    rules=None,
+    results=None,
+) -> dict:
+    if rules is None:
+        rules = [{"id": "rule-1", "name": "Rule One"}]
+    if results is None:
+        results = [make_result()]
+    return {
+        "tool": {"driver": {"name": driver_name, "rules": rules}},
+        "results": results,
+    }
+
+
+def make_result(
+    rule_id="rule-1",
+    level="warning",
+    uri="src/app.py",
+    start_line=10,
+) -> dict:
+    result: dict = {}
+    if rule_id:
+        result["ruleId"] = rule_id
+    if level:
+        result["level"] = level
+    result["locations"] = [
+        {
+            "physicalLocation": {
+                "artifactLocation": {"uri": uri},
+                "region": {"startLine": start_line},
+            }
+        }
+    ]
+    return result
+
+
+def write_sarif(tmp_path, data: dict) -> str:
+    path = tmp_path / "test.sarif"
+    path.write_text(json.dumps(data))
+    return str(path)
+
+
+# --- validate_json ---
+
+def test_validate_json_valid():
+    sarif, c = validate.validate_json('{"version": "2.1.0"}')
+    assert c["status"] == "pass"
+    assert sarif == {"version": "2.1.0"}
+
+def test_validate_json_invalid():
+    sarif, c = validate.validate_json("{not valid json")
+    assert c["status"] == "fail"
+    assert sarif is None
+
+
+# --- validate_top_level ---
+
+def test_top_level_valid():
+    checks = validate.validate_top_level(make_sarif())
+    assert all(c["status"] == "pass" for c in checks)
+
+def test_top_level_missing_version():
+    checks = validate.validate_top_level(make_sarif(include_version=False))
+    statuses = [c["status"] for c in checks]
+    assert "fail" in statuses
+
+def test_top_level_unsupported_version():
+    checks = validate.validate_top_level(make_sarif(version="1.0.0"))
+    assert any(c["status"] == "fail" and "Unsupported" in c["message"] for c in checks)
+
+def test_top_level_missing_runs():
+    checks = validate.validate_top_level(make_sarif(include_runs=False))
+    assert any(c["status"] == "fail" and "runs" in c["message"] for c in checks)
+
+def test_top_level_empty_runs():
+    checks = validate.validate_top_level(make_sarif(runs=[]))
+    assert any(c["status"] == "fail" for c in checks)
+
+
+# --- validate_run ---
+
+def test_run_valid():
+    checks, result_count, rule_count = validate.validate_run(make_run(), 0)
+    assert all(c["status"] == "pass" for c in checks)
+    assert result_count == 1
+    assert rule_count == 1
+
+def test_run_missing_driver_name():
+    run = make_run(driver_name=None)
+    del run["tool"]["driver"]["name"]
+    checks, _, _ = validate.validate_run(run, 0)
+    assert any(c["status"] == "fail" and "driver.name" in c["message"] for c in checks)
+
+def test_run_duplicate_rule_ids():
+    rules = [{"id": "rule-1"}, {"id": "rule-1"}]
+    run = make_run(rules=rules, results=[])
+    checks, _, _ = validate.validate_run(run, 0)
+    assert any(c["status"] == "fail" and "duplicate" in c["message"] for c in checks)
+
+def test_run_unknown_rule_id():
+    results = [make_result(rule_id="unknown-rule")]
+    run = make_run(rules=[{"id": "rule-1"}], results=results)
+    checks, _, _ = validate.validate_run(run, 0)
+    assert any(c["status"] == "fail" and "unknown ruleIds" in c["message"] for c in checks)
+
+def test_run_result_with_no_rules_defined_passes():
+    run = make_run(rules=[], results=[make_result(rule_id="any-rule")])
+    checks, _, _ = validate.validate_run(run, 0)
+    assert not any(c["status"] == "fail" and "unknown ruleIds" in c["message"] for c in checks)
+
+def test_run_invalid_level():
+    results = [make_result(level="critical")]
+    run = make_run(results=results)
+    checks, _, _ = validate.validate_run(run, 0)
+    assert any(c["status"] == "fail" and "invalid level" in c["message"] for c in checks)
+
+def test_run_all_valid_levels():
+    for level in ("error", "warning", "note", "none"):
+        results = [make_result(level=level)]
+        run = make_run(results=results)
+        checks, _, _ = validate.validate_run(run, 0)
+        assert not any(c["status"] == "fail" and "invalid level" in c["message"] for c in checks)
+
+def test_run_absolute_unix_uri():
+    results = [make_result(uri="/home/runner/work/repo/src/app.py")]
+    run = make_run(results=results)
+    checks, _, _ = validate.validate_run(run, 0)
+    assert any(c["status"] == "warn" and "absolute" in c["message"] for c in checks)
+
+def test_run_absolute_windows_uri():
+    results = [make_result(uri="C:\\Users\\runner\\src\\app.py")]
+    run = make_run(results=results)
+    checks, _, _ = validate.validate_run(run, 0)
+    assert any(c["status"] == "warn" and "absolute" in c["message"] for c in checks)
+
+def test_run_relative_uri_passes():
+    results = [make_result(uri="src/app.py")]
+    run = make_run(results=results)
+    checks, _, _ = validate.validate_run(run, 0)
+    assert not any("absolute" in c["message"] for c in checks)
+
+def test_run_missing_start_line():
+    result = make_result()
+    result["locations"][0]["physicalLocation"]["region"] = {}
+    run = make_run(results=[result])
+    checks, _, _ = validate.validate_run(run, 0)
+    assert any(c["status"] == "warn" and "missing a valid location" in c["message"] for c in checks)
+
+def test_run_no_locations():
+    result = make_result()
+    result["locations"] = []
+    run = make_run(results=[result])
+    checks, _, _ = validate.validate_run(run, 0)
+    assert any(c["status"] == "warn" and "missing a valid location" in c["message"] for c in checks)
+
+def test_run_counts():
+    rules = [{"id": "r1"}, {"id": "r2"}]
+    results = [make_result("r1"), make_result("r2"), make_result("r1")]
+    _, result_count, rule_count = validate.validate_run(make_run(rules=rules, results=results), 0)
+    assert result_count == 3
+    assert rule_count == 2
+
+
+# --- main: input validation ---
+
+def test_main_missing_sarif_file_exits_2():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 2
+
+def test_main_file_not_found_exits_2():
+    with patch.dict(os.environ, {"INPUT_SARIF_FILE": "/nonexistent/file.sarif"}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 2
+
+
+# --- main: end-to-end ---
+
+def test_main_valid_sarif_exits_0(tmp_path):
+    path = write_sarif(tmp_path, make_sarif())
+    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": ""}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 0
+
+def test_main_invalid_json_exits_1(tmp_path):
+    path = tmp_path / "bad.sarif"
+    path.write_text("{not json")
+    with patch.dict(os.environ, {"INPUT_SARIF_FILE": str(path), "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": ""}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 1
+
+def test_main_wrong_version_exits_1(tmp_path):
+    path = write_sarif(tmp_path, make_sarif(version="1.0.0"))
+    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": ""}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 1
+
+def test_main_warnings_pass_non_strict(tmp_path):
+    results = [make_result(uri="/absolute/path.py")]
+    path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
+    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": ""}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 0
+
+def test_main_warnings_fail_strict(tmp_path):
+    results = [make_result(uri="/absolute/path.py")]
+    path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
+    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "true", "INPUT_MAX_RESULTS": ""}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 1
+
+def test_main_max_results_exceeded_warns(tmp_path, capsys):
+    results = [make_result() for _ in range(5)]
+    path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
+    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": "3"}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 0
+    assert "exceeds max_results" in capsys.readouterr().out
+
+def test_main_max_results_exceeded_fails_strict(tmp_path):
+    results = [make_result() for _ in range(5)]
+    path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
+    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "true", "INPUT_MAX_RESULTS": "3"}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary

- Adds `sarif-validator` action — validates SARIF files before uploading to GitHub code scanning
- Catches JSON errors, bad schema versions, missing required fields, duplicate rule IDs, unknown ruleId references, absolute URI paths, invalid level values
- Strict mode fails on warnings; configurable max_results threshold
- No external dependencies — pure Python stdlib

Closes #9

## Test plan

- [ ] 29 unit tests passing locally (`pytest tests/sarif-validator/ -v`)
- [ ] Validated against real CodeQL SARIF from `cschooley/vulnado` — clean pass, 2 results
- [ ] CI passing