### PR TITLE
feat: add fail_on_findings advisory mode (#19)

### DIFF
--- a/.github/workflows/codeql-advanced.yml
+++ b/.github/workflows/codeql-advanced.yml
@@ -3,6 +3,8 @@ name: CodeQL Advanced
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     # Deep scan nightly
     - cron: "0 2 * * *"

--- a/actions/dependency-review-gate/action.yml
+++ b/actions/dependency-review-gate/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'Post a summary comment on the PR'
     required: false
     default: 'true'
+  fail_on_findings:
+    description: 'Exit 1 if violations are found. Set to false for advisory/observe mode.'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -61,3 +65,4 @@ runs:
         INPUT_DENY_LICENSES: ${{ inputs.deny_licenses }}
         INPUT_IGNORE_CVES: ${{ inputs.ignore_cves }}
         INPUT_COMMENT_ON_PR: ${{ inputs.comment_on_pr }}
+        INPUT_FAIL_ON_FINDINGS: ${{ inputs.fail_on_findings }}

--- a/actions/dependency-review-gate/src/gate.py
+++ b/actions/dependency-review-gate/src/gate.py
@@ -141,7 +141,7 @@ def evaluate_changes(
     return violations, ignored
 
 
-def build_comment(violations: list[dict], ignored: list[dict], passed: bool) -> str:
+def build_comment(violations: list[dict], ignored: list[dict], passed: bool, advisory: bool = False) -> str:
     lines = []
 
     if passed:
@@ -152,6 +152,10 @@ def build_comment(violations: list[dict], ignored: list[dict], passed: bool) -> 
         lines.append("## Dependency Review Gate: FAILED")
         lines.append("")
         lines.append(f"{len(violations)} issue(s) found in added dependencies.")
+        if advisory:
+            lines.append("")
+            lines.append("> [!WARNING]")
+            lines.append("> Advisory mode — findings detected but check is non-blocking.")
 
     if violations:
         lines.append("")
@@ -200,6 +204,7 @@ def main() -> None:
     deny_licenses_raw = os.environ.get("INPUT_DENY_LICENSES", "").strip()
     ignore_cves_raw = os.environ.get("INPUT_IGNORE_CVES", "").strip()
     comment_on_pr = os.environ.get("INPUT_COMMENT_ON_PR", "true").strip().lower() in ("true", "1", "yes")
+    fail_on_findings = os.environ.get("INPUT_FAIL_ON_FINDINGS", "true").strip().lower() in ("true", "1", "yes")
 
     if not token:
         print("ERROR: 'token' input is required.", file=sys.stderr)
@@ -252,13 +257,13 @@ def main() -> None:
         print("\nPASSED — no violations found")
 
     if comment_on_pr and pr_number:
-        comment = build_comment(violations, ignored, passed)
+        comment = build_comment(violations, ignored, passed, advisory=not fail_on_findings)
         post_pr_comment(session, repo, pr_number, comment)
         print(f"  PR comment posted on #{pr_number}")
     elif comment_on_pr and not pr_number:
         print("  WARNING: comment_on_pr is true but no PR number provided — skipping comment", file=sys.stderr)
 
-    if not passed:
+    if not passed and fail_on_findings:
         sys.exit(1)
     sys.exit(0)
 

--- a/actions/sarif-validator/action.yml
+++ b/actions/sarif-validator/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Warn if result count exceeds this threshold'
     required: false
     default: ''
+  fail_on_findings:
+    description: 'Exit 1 if validation errors or warnings (in strict mode) are found. Set to false for advisory/observe mode.'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -25,3 +29,4 @@ runs:
         INPUT_SARIF_FILE: ${{ inputs.sarif_file }}
         INPUT_STRICT: ${{ inputs.strict }}
         INPUT_MAX_RESULTS: ${{ inputs.max_results }}
+        INPUT_FAIL_ON_FINDINGS: ${{ inputs.fail_on_findings }}

--- a/actions/sarif-validator/src/validate.py
+++ b/actions/sarif-validator/src/validate.py
@@ -126,6 +126,7 @@ def main() -> None:
     sarif_file = os.environ.get("INPUT_SARIF_FILE", "").strip()
     strict = os.environ.get("INPUT_STRICT", "false").strip().lower() in ("true", "1", "yes")
     max_results_raw = os.environ.get("INPUT_MAX_RESULTS", "").strip()
+    fail_on_findings = os.environ.get("INPUT_FAIL_ON_FINDINGS", "true").strip().lower() in ("true", "1", "yes")
     max_results = int(max_results_raw) if max_results_raw.isdigit() else None
 
     if not sarif_file:
@@ -180,9 +181,15 @@ def main() -> None:
 
     if has_failures:
         print(f"\nResult: FAIL ({sum(1 for c in all_checks if c['status'] == 'fail')} error(s))")
+        if not fail_on_findings:
+            print("Advisory mode — check is non-blocking.")
+            sys.exit(0)
         sys.exit(1)
     if strict and has_warnings:
         print(f"\nResult: FAIL — strict mode ({sum(1 for c in all_checks if c['status'] == 'warn')} warning(s))")
+        if not fail_on_findings:
+            print("Advisory mode — check is non-blocking.")
+            sys.exit(0)
         sys.exit(1)
     print("\nResult: PASS")
     sys.exit(0)

--- a/tests/dependency-review-gate/test_gate.py
+++ b/tests/dependency-review-gate/test_gate.py
@@ -214,6 +214,29 @@ def test_build_comment_ignored_audit_trail():
     assert "Ignored" in comment
     assert "GHSA-audit" in comment
 
+def test_build_comment_advisory_mode_includes_note():
+    violations = [{
+        "package": "pkg", "version": "1.0", "ecosystem": "npm",
+        "severity": "high", "cve": "GHSA-xxxx", "license": "MIT",
+        "reason": "vulnerability (high)",
+    }]
+    comment = gate.build_comment(violations, [], passed=False, advisory=True)
+    assert "Advisory mode" in comment
+    assert "non-blocking" in comment
+
+def test_build_comment_advisory_note_absent_when_not_advisory():
+    violations = [{
+        "package": "pkg", "version": "1.0", "ecosystem": "npm",
+        "severity": "high", "cve": "GHSA-xxxx", "license": "MIT",
+        "reason": "vulnerability (high)",
+    }]
+    comment = gate.build_comment(violations, [], passed=False, advisory=False)
+    assert "Advisory mode" not in comment
+
+def test_build_comment_advisory_note_absent_when_passed():
+    comment = gate.build_comment([], [], passed=True, advisory=True)
+    assert "Advisory mode" not in comment
+
 def test_build_comment_none_severity_renders_dash():
     violations = [{
         "package": "badpkg", "version": "1.0", "ecosystem": "npm",
@@ -252,6 +275,7 @@ BASE_ENV = {
     "INPUT_DENY_LICENSES": "",
     "INPUT_IGNORE_CVES": "",
     "INPUT_COMMENT_ON_PR": "true",
+    "INPUT_FAIL_ON_FINDINGS": "true",
 }
 
 def test_main_missing_token(capsys):
@@ -323,6 +347,28 @@ def test_main_posts_comment_when_pr_number_set(capsys):
                 with pytest.raises(SystemExit):
                     gate.main()
     mock_comment.assert_called_once()
+
+def test_main_advisory_mode_exits_0_with_violations(capsys):
+    change = make_change(vulnerabilities=[make_vuln("critical")])
+    env = {**BASE_ENV, "INPUT_COMMENT_ON_PR": "false", "INPUT_FAIL_ON_FINDINGS": "false"}
+    with patch.dict(os.environ, env, clear=True):
+        with patch("gate.get_dependency_changes", return_value=[change]):
+            with pytest.raises(SystemExit) as exc:
+                gate.main()
+    assert exc.value.code == 0
+    assert "FAILED" in capsys.readouterr().out
+
+def test_main_advisory_mode_posts_comment_with_advisory_note(capsys):
+    change = make_change(vulnerabilities=[make_vuln("high")])
+    env = {**BASE_ENV, "INPUT_PR_NUMBER": "5", "INPUT_FAIL_ON_FINDINGS": "false"}
+    with patch.dict(os.environ, env, clear=True):
+        with patch("gate.get_dependency_changes", return_value=[change]):
+            with patch("gate.post_pr_comment") as mock_comment:
+                with pytest.raises(SystemExit):
+                    gate.main()
+    mock_comment.assert_called_once()
+    comment_body = mock_comment.call_args[0][3]
+    assert "Advisory mode" in comment_body
 
 def test_main_warns_when_comment_true_no_pr(capsys):
     env = {**BASE_ENV, "INPUT_PR_NUMBER": "", "INPUT_COMMENT_ON_PR": "true"}

--- a/tests/sarif-validator/test_validate.py
+++ b/tests/sarif-validator/test_validate.py
@@ -204,9 +204,12 @@ def test_main_file_not_found_exits_2():
 
 # --- main: end-to-end ---
 
+BASE_ENV = {"INPUT_STRICT": "false", "INPUT_MAX_RESULTS": "", "INPUT_FAIL_ON_FINDINGS": "true"}
+
+
 def test_main_valid_sarif_exits_0(tmp_path):
     path = write_sarif(tmp_path, make_sarif())
-    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": ""}, clear=True):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path}, clear=True):
         with pytest.raises(SystemExit) as exc:
             validate.main()
     assert exc.value.code == 0
@@ -214,14 +217,14 @@ def test_main_valid_sarif_exits_0(tmp_path):
 def test_main_invalid_json_exits_1(tmp_path):
     path = tmp_path / "bad.sarif"
     path.write_text("{not json")
-    with patch.dict(os.environ, {"INPUT_SARIF_FILE": str(path), "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": ""}, clear=True):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": str(path)}, clear=True):
         with pytest.raises(SystemExit) as exc:
             validate.main()
     assert exc.value.code == 1
 
 def test_main_wrong_version_exits_1(tmp_path):
     path = write_sarif(tmp_path, make_sarif(version="1.0.0"))
-    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": ""}, clear=True):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path}, clear=True):
         with pytest.raises(SystemExit) as exc:
             validate.main()
     assert exc.value.code == 1
@@ -229,7 +232,7 @@ def test_main_wrong_version_exits_1(tmp_path):
 def test_main_warnings_pass_non_strict(tmp_path):
     results = [make_result(uri="/absolute/path.py")]
     path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
-    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": ""}, clear=True):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path}, clear=True):
         with pytest.raises(SystemExit) as exc:
             validate.main()
     assert exc.value.code == 0
@@ -237,7 +240,7 @@ def test_main_warnings_pass_non_strict(tmp_path):
 def test_main_warnings_fail_strict(tmp_path):
     results = [make_result(uri="/absolute/path.py")]
     path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
-    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "true", "INPUT_MAX_RESULTS": ""}, clear=True):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path, "INPUT_STRICT": "true"}, clear=True):
         with pytest.raises(SystemExit) as exc:
             validate.main()
     assert exc.value.code == 1
@@ -245,7 +248,7 @@ def test_main_warnings_fail_strict(tmp_path):
 def test_main_max_results_exceeded_warns(tmp_path, capsys):
     results = [make_result() for _ in range(5)]
     path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
-    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "false", "INPUT_MAX_RESULTS": "3"}, clear=True):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path, "INPUT_MAX_RESULTS": "3"}, clear=True):
         with pytest.raises(SystemExit) as exc:
             validate.main()
     assert exc.value.code == 0
@@ -254,7 +257,32 @@ def test_main_max_results_exceeded_warns(tmp_path, capsys):
 def test_main_max_results_exceeded_fails_strict(tmp_path):
     results = [make_result() for _ in range(5)]
     path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
-    with patch.dict(os.environ, {"INPUT_SARIF_FILE": path, "INPUT_STRICT": "true", "INPUT_MAX_RESULTS": "3"}, clear=True):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path, "INPUT_STRICT": "true", "INPUT_MAX_RESULTS": "3"}, clear=True):
         with pytest.raises(SystemExit) as exc:
             validate.main()
     assert exc.value.code == 1
+
+
+# --- advisory mode ---
+
+def test_main_advisory_mode_exits_0_on_fail(tmp_path):
+    path = write_sarif(tmp_path, make_sarif(version="1.0.0"))
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path, "INPUT_FAIL_ON_FINDINGS": "false"}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 0
+
+def test_main_advisory_mode_exits_0_on_strict_warn(tmp_path):
+    results = [make_result(uri="/absolute/path.py")]
+    path = write_sarif(tmp_path, make_sarif(runs=[make_run(results=results)]))
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path, "INPUT_STRICT": "true", "INPUT_FAIL_ON_FINDINGS": "false"}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            validate.main()
+    assert exc.value.code == 0
+
+def test_main_advisory_mode_prints_advisory_note(tmp_path, capsys):
+    path = write_sarif(tmp_path, make_sarif(version="1.0.0"))
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SARIF_FILE": path, "INPUT_FAIL_ON_FINDINGS": "false"}, clear=True):
+        with pytest.raises(SystemExit):
+            validate.main()
+    assert "Advisory mode" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Adds `fail_on_findings` input (default: `true`) to `dependency-review-gate` and `sarif-validator`
- When `false`, the action posts the PR comment / prints validation output as normal but always exits 0
- PR comment includes a GitHub-native `[!WARNING]` advisory note when in advisory mode so reviewers know the gate is non-blocking
- Unblocks `ai-pr-reviewer` (#18) which should include this input from day one

## Test plan

- [x] 147/147 unit tests pass
- [x] `sarif-validator` smoke tested locally — advisory mode exits 0 with `[FAIL]` findings, enforcement mode exits 1
- [x] `dependency-review-gate` advisory path covered by unit tests (exit code + comment content assertions)

Closes #19