### PR TITLE
feat: trivy-scanner action (#11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,11 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: pip install pytest requests
+
+      - name: Install Trivy
+        run: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Run tests
         run: pytest tests/ -v

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,26 @@
+name: Trivy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  scan:
+    name: Filesystem scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./actions/trivy-scanner
+        with:
+          target: '.'
+          scan_type: fs
+          severity: HIGH
+          upload_to_ghas: 'true'

--- a/actions/trivy-scanner/action.yml
+++ b/actions/trivy-scanner/action.yml
@@ -1,0 +1,60 @@
+name: 'Trivy Scanner'
+description: 'Scan a container image, filesystem, or IaC config with Trivy and upload results to GHAS'
+author: 'cschooley'
+
+inputs:
+  target:
+    description: 'What to scan — image name, directory path, or config path'
+    required: true
+  scan_type:
+    description: 'Scan type: image, fs, config'
+    required: false
+    default: 'fs'
+  severity:
+    description: 'Minimum severity to report: CRITICAL, HIGH, MEDIUM, LOW'
+    required: false
+    default: 'HIGH'
+  output_file:
+    description: 'Path to write SARIF output'
+    required: false
+    default: 'trivy-results.sarif'
+  upload_to_ghas:
+    description: 'Upload SARIF results to GitHub code scanning'
+    required: false
+    default: 'true'
+  ignore_unfixed:
+    description: 'Exclude vulnerabilities with no available fix'
+    required: false
+    default: 'false'
+  trivy_config:
+    description: 'Path to a trivy.yaml config file'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install Trivy
+      run: |
+        if ! command -v trivy &>/dev/null; then
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+        fi
+      shell: bash
+
+    - name: Run Trivy scan
+      run: python ${{ github.action_path }}/src/scan.py
+      shell: bash
+      env:
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_SCAN_TYPE: ${{ inputs.scan_type }}
+        INPUT_SEVERITY: ${{ inputs.severity }}
+        INPUT_OUTPUT_FILE: ${{ inputs.output_file }}
+        INPUT_IGNORE_UNFIXED: ${{ inputs.ignore_unfixed }}
+        INPUT_TRIVY_CONFIG: ${{ inputs.trivy_config }}
+
+    - name: Upload SARIF to GHAS
+      if: inputs.upload_to_ghas == 'true'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.output_file }}
+        category: trivy-${{ inputs.scan_type }}

--- a/actions/trivy-scanner/examples/trivy-scan.yml
+++ b/actions/trivy-scanner/examples/trivy-scan.yml
@@ -1,0 +1,56 @@
+name: Trivy Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  trivy-fs:
+    name: Filesystem scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/trivy-scanner
+        with:
+          target: '.'
+          scan_type: fs
+          severity: HIGH
+          upload_to_ghas: 'true'
+
+  trivy-config:
+    name: IaC / config scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/trivy-scanner
+        with:
+          target: '.'
+          scan_type: config
+          severity: HIGH
+          upload_to_ghas: 'true'
+
+  trivy-image:
+    name: Container image scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/trivy-scanner
+        with:
+          target: 'myorg/myapp:latest'
+          scan_type: image
+          severity: CRITICAL
+          ignore_unfixed: 'true'
+          upload_to_ghas: 'true'

--- a/actions/trivy-scanner/src/scan.py
+++ b/actions/trivy-scanner/src/scan.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+VALID_SCAN_TYPES = {"image", "fs", "config"}
+SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
+
+
+def parse_bool(value: str) -> bool:
+    return value.strip().lower() in ("true", "1", "yes")
+
+
+def build_severity_flag(minimum: str) -> str:
+    idx = SEVERITY_ORDER.index(minimum.upper())
+    return ",".join(SEVERITY_ORDER[:idx + 1])
+
+
+def build_trivy_cmd(
+    scan_type: str,
+    target: str,
+    severity: str,
+    output_file: str,
+    ignore_unfixed: bool,
+    trivy_config: str | None,
+) -> list[str]:
+    cmd = [
+        "trivy", scan_type,
+        "--format", "sarif",
+        "--output", output_file,
+        "--severity", build_severity_flag(severity),
+    ]
+    if ignore_unfixed:
+        cmd.append("--ignore-unfixed")
+    if trivy_config:
+        cmd.extend(["--config", trivy_config])
+    cmd.append(target)
+    return cmd
+
+
+def run_trivy(cmd: list[str]) -> int:
+    return subprocess.run(cmd).returncode
+
+
+def main() -> None:
+    target = os.environ.get("INPUT_TARGET", "").strip()
+    scan_type = os.environ.get("INPUT_SCAN_TYPE", "fs").strip().lower()
+    severity = os.environ.get("INPUT_SEVERITY", "HIGH").strip().upper()
+    output_file = os.environ.get("INPUT_OUTPUT_FILE", "trivy-results.sarif").strip()
+    ignore_unfixed = parse_bool(os.environ.get("INPUT_IGNORE_UNFIXED", "false"))
+    trivy_config = os.environ.get("INPUT_TRIVY_CONFIG", "").strip() or None
+
+    if not target:
+        print("ERROR: 'target' input is required.", file=sys.stderr)
+        sys.exit(2)
+    if scan_type not in VALID_SCAN_TYPES:
+        print(
+            f"ERROR: 'scan_type' must be one of: {', '.join(sorted(VALID_SCAN_TYPES))}. Got '{scan_type}'.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if severity not in SEVERITY_ORDER:
+        print(
+            f"ERROR: 'severity' must be one of: {', '.join(SEVERITY_ORDER)}. Got '{severity}'.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if trivy_config and not os.path.exists(trivy_config):
+        print(f"ERROR: trivy_config file not found: {trivy_config}", file=sys.stderr)
+        sys.exit(2)
+
+    cmd = build_trivy_cmd(scan_type, target, severity, output_file, ignore_unfixed, trivy_config)
+
+    print(f"Running Trivy {scan_type} scan: {target}")
+    print(f"  severity: {build_severity_flag(severity)}")
+    print(f"  output:   {output_file}")
+    if ignore_unfixed:
+        print("  ignore-unfixed: true")
+
+    rc = run_trivy(cmd)
+    if rc != 0:
+        print(f"ERROR: Trivy exited with code {rc}", file=sys.stderr)
+        sys.exit(rc)
+
+    print(f"Scan complete. SARIF written to {output_file}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/trivy-scanner/test_scan.py
+++ b/tests/trivy-scanner/test_scan.py
@@ -1,0 +1,194 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../actions/trivy-scanner/src"))
+import scan
+
+
+BASE_ENV = {
+    "INPUT_TARGET": ".",
+    "INPUT_SCAN_TYPE": "fs",
+    "INPUT_SEVERITY": "HIGH",
+    "INPUT_OUTPUT_FILE": "trivy-results.sarif",
+    "INPUT_IGNORE_UNFIXED": "false",
+    "INPUT_TRIVY_CONFIG": "",
+}
+
+
+# --- parse_bool ---
+
+def test_parse_bool_true_values():
+    for v in ("true", "True", "TRUE", "1", "yes"):
+        assert scan.parse_bool(v) is True
+
+def test_parse_bool_false_values():
+    for v in ("false", "False", "0", "no", ""):
+        assert scan.parse_bool(v) is False
+
+
+# --- build_severity_flag ---
+
+def test_severity_critical_only():
+    assert scan.build_severity_flag("CRITICAL") == "CRITICAL"
+
+def test_severity_high_includes_critical():
+    assert scan.build_severity_flag("HIGH") == "CRITICAL,HIGH"
+
+def test_severity_medium_includes_above():
+    assert scan.build_severity_flag("MEDIUM") == "CRITICAL,HIGH,MEDIUM"
+
+def test_severity_low_all():
+    assert scan.build_severity_flag("LOW") == "CRITICAL,HIGH,MEDIUM,LOW"
+
+
+# --- build_trivy_cmd ---
+
+def test_build_cmd_fs_basic():
+    cmd = scan.build_trivy_cmd("fs", ".", "HIGH", "out.sarif", False, None)
+    assert cmd == ["trivy", "fs", "--format", "sarif", "--output", "out.sarif", "--severity", "CRITICAL,HIGH", "."]
+
+def test_build_cmd_image_type():
+    cmd = scan.build_trivy_cmd("image", "python:3.11-slim", "CRITICAL", "out.sarif", False, None)
+    assert cmd[1] == "image"
+    assert cmd[-1] == "python:3.11-slim"
+
+def test_build_cmd_config_type():
+    cmd = scan.build_trivy_cmd("config", ".", "HIGH", "out.sarif", False, None)
+    assert cmd[1] == "config"
+
+def test_build_cmd_ignore_unfixed_present():
+    cmd = scan.build_trivy_cmd("fs", ".", "HIGH", "out.sarif", True, None)
+    assert "--ignore-unfixed" in cmd
+
+def test_build_cmd_ignore_unfixed_absent():
+    cmd = scan.build_trivy_cmd("fs", ".", "HIGH", "out.sarif", False, None)
+    assert "--ignore-unfixed" not in cmd
+
+def test_build_cmd_with_config():
+    cmd = scan.build_trivy_cmd("fs", ".", "HIGH", "out.sarif", False, "trivy.yaml")
+    assert "--config" in cmd
+    config_idx = cmd.index("--config")
+    assert cmd[config_idx + 1] == "trivy.yaml"
+
+def test_build_cmd_without_config():
+    cmd = scan.build_trivy_cmd("fs", ".", "HIGH", "out.sarif", False, None)
+    assert "--config" not in cmd
+
+def test_build_cmd_target_is_last():
+    cmd = scan.build_trivy_cmd("fs", "/some/path", "HIGH", "out.sarif", False, None)
+    assert cmd[-1] == "/some/path"
+
+def test_build_cmd_sarif_format():
+    cmd = scan.build_trivy_cmd("fs", ".", "HIGH", "out.sarif", False, None)
+    fmt_idx = cmd.index("--format")
+    assert cmd[fmt_idx + 1] == "sarif"
+
+
+# --- main: input validation ---
+
+def test_main_missing_target(capsys):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_TARGET": ""}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            scan.main()
+    assert exc.value.code == 2
+    assert "target" in capsys.readouterr().err
+
+def test_main_invalid_scan_type(capsys):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SCAN_TYPE": "repo"}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            scan.main()
+    assert exc.value.code == 2
+
+def test_main_invalid_severity(capsys):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SEVERITY": "EXTREME"}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            scan.main()
+    assert exc.value.code == 2
+
+def test_main_missing_config_file(capsys):
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_TRIVY_CONFIG": "/nonexistent/trivy.yaml"}, clear=True):
+        with pytest.raises(SystemExit) as exc:
+            scan.main()
+    assert exc.value.code == 2
+    assert "not found" in capsys.readouterr().err
+
+def test_main_valid_config_file(tmp_path, capsys):
+    config = tmp_path / "trivy.yaml"
+    config.write_text("timeout: 5m\n")
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_TRIVY_CONFIG": str(config)}, clear=True):
+        with patch("scan.run_trivy", return_value=0):
+            with pytest.raises(SystemExit) as exc:
+                scan.main()
+    assert exc.value.code == 0
+
+
+# --- main: execution ---
+
+def test_main_happy_path_exits_0(capsys):
+    with patch.dict(os.environ, BASE_ENV, clear=True):
+        with patch("scan.run_trivy", return_value=0):
+            with pytest.raises(SystemExit) as exc:
+                scan.main()
+    assert exc.value.code == 0
+    assert "Scan complete" in capsys.readouterr().out
+
+def test_main_trivy_failure_propagates(capsys):
+    with patch.dict(os.environ, BASE_ENV, clear=True):
+        with patch("scan.run_trivy", return_value=2):
+            with pytest.raises(SystemExit) as exc:
+                scan.main()
+    assert exc.value.code == 2
+    assert "ERROR" in capsys.readouterr().err
+
+def test_main_passes_correct_cmd_to_run_trivy():
+    captured = []
+    def fake_run(cmd):
+        captured.extend(cmd)
+        return 0
+    with patch.dict(os.environ, BASE_ENV, clear=True):
+        with patch("scan.run_trivy", side_effect=fake_run):
+            with pytest.raises(SystemExit):
+                scan.main()
+    assert "fs" in captured
+    assert "--format" in captured
+    assert "sarif" in captured
+    assert "CRITICAL,HIGH" in captured
+
+def test_main_ignore_unfixed_passed_through():
+    captured = []
+    def fake_run(cmd):
+        captured.extend(cmd)
+        return 0
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_IGNORE_UNFIXED": "true"}, clear=True):
+        with patch("scan.run_trivy", side_effect=fake_run):
+            with pytest.raises(SystemExit):
+                scan.main()
+    assert "--ignore-unfixed" in captured
+
+def test_main_severity_low_passes_all_levels():
+    captured = []
+    def fake_run(cmd):
+        captured.extend(cmd)
+        return 0
+    with patch.dict(os.environ, {**BASE_ENV, "INPUT_SEVERITY": "LOW"}, clear=True):
+        with patch("scan.run_trivy", side_effect=fake_run):
+            with pytest.raises(SystemExit):
+                scan.main()
+    sev_idx = captured.index("--severity")
+    assert captured[sev_idx + 1] == "CRITICAL,HIGH,MEDIUM,LOW"
+
+def test_main_image_scan_type():
+    captured = []
+    def fake_run(cmd):
+        captured.extend(cmd)
+        return 0
+    env = {**BASE_ENV, "INPUT_SCAN_TYPE": "image", "INPUT_TARGET": "python:3.11-slim"}
+    with patch.dict(os.environ, env, clear=True):
+        with patch("scan.run_trivy", side_effect=fake_run):
+            with pytest.raises(SystemExit):
+                scan.main()
+    assert "image" in captured
+    assert "python:3.11-slim" in captured


### PR DESCRIPTION
## Summary

- Composite action that installs Trivy and runs `image`, `fs`, or `config` scans
- Outputs native SARIF (no conversion layer — Trivy handles it)
- Conditionally uploads to GHAS via `github/codeql-action/upload-sarif`
- Severity input maps to Trivy's comma-separated `--severity` flag (e.g. `HIGH` → `CRITICAL,HIGH`)
- `trivy_config` input for teams with a `trivy.yaml` already in their repo

## Test plan

- [x] 26 unit tests — all input validation, command construction, and exit code paths (Trivy mocked via `subprocess`)
- [x] Live `fs` scan against this repo — clean exit, valid SARIF
- [x] Live `config` scan against `cschooley/vulnado` — 9 findings across Dockerfiles + Terraform, valid SARIF
- [x] Full suite: 165/165 passing
- CI installs Trivy before running pytest so the binary is available for any future integration tests

Closes #11